### PR TITLE
Fix missing API_URL constant

### DIFF
--- a/mobile/src/constants/api.ts
+++ b/mobile/src/constants/api.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3000";


### PR DESCRIPTION
## Summary
- add an `API_URL` constant

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686584474ee8832c8ccfe796cd3ebf07