### PR TITLE
Fix @ alias path

### DIFF
--- a/mobile/src/babel.config.js
+++ b/mobile/src/babel.config.js
@@ -1,0 +1,14 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      ['module-resolver', {
+        alias: {
+          '@': './'
+        }
+      }],
+      'expo-router/babel'
+    ]
+  };
+};

--- a/mobile/src/tsconfig.json
+++ b/mobile/src/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]


### PR DESCRIPTION
## Summary
- fix tsconfig path alias so `@` resolves to the mobile src root
- set up Babel config with `module-resolver`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865860cea24832cb1fc9c0e5e1b01a1