### PR TITLE
Replace AlarmCard with reusable Card

### DIFF
--- a/mobile/src/app/(tabs)/Home/index.tsx
+++ b/mobile/src/app/(tabs)/Home/index.tsx
@@ -2,10 +2,11 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { FlatList, Switch, TouchableOpacity, RefreshControl } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import {
-  Container, Header, PremiumButton, PremiumText, NextAlarmLabel, NextAlarmTime,
-  AlarmCard, AlarmHeader, DayText, AlarmHour, Mission, Fab,
+  Container, Header, PremiumButton, PremiumText, NextAlarmTime,
+  AlarmHeader, DayText, AlarmHour, Mission, Fab,
   DaysContainer
 } from './styles';
+import Card from '@/components/Card';
 import { router, useFocusEffect } from 'expo-router';
 import { API_URL } from '@/constants/api';
 
@@ -129,7 +130,7 @@ export default function AlarmeHomeScreen() {
         keyExtractor={item => String(item.id)}
         renderItem={({ item }) => (
           <TouchableOpacity onPress={() => router.push({ pathname: '/(tabs)/Home/detalhesAlarme/[id]', params: { id: item.id } })}>
-            <AlarmCard ativo={item.ativo}>
+            <Card ativo={item.ativo}>
               <AlarmHeader>
                 <DaysContainer>
                   <React.Fragment>
@@ -152,7 +153,7 @@ export default function AlarmeHomeScreen() {
               </AlarmHeader>
               <AlarmHour>{item.horario}</AlarmHour>
               <Mission>{item.missao ?? 'Missão'}</Mission>
-            </AlarmCard>
+            </Card>
           </TouchableOpacity>
         )}
         contentContainerStyle={{ paddingBottom: 100 }}

--- a/mobile/src/app/(tabs)/Home/styles.ts
+++ b/mobile/src/app/(tabs)/Home/styles.ts
@@ -38,17 +38,6 @@ export const NextAlarmTime = styled.Text`
   margin-bottom: 22px;
 `;
 
-export const AlarmCard = styled.View.attrs<{ ativo?: boolean }>(props => ({
-  style: {
-    opacity: props.ativo ? 1 : 0.4,
-  },
-}))`
-  background-color: #23242a;
-  border-radius: 16px;
-  padding: 18px;
-  margin-bottom: 18px;
-  position: relative;
-`;
 
 export const AlarmHeader = styled.View`
   flex-direction: row;

--- a/mobile/src/components/Card/index.tsx
+++ b/mobile/src/components/Card/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { CardContainer } from './styles';
+
+export interface CardProps {
+  children: React.ReactNode;
+  ativo?: boolean;
+}
+
+export function Card({ children, ativo }: CardProps) {
+  return <CardContainer ativo={ativo}>{children}</CardContainer>;
+}
+
+export default Card;

--- a/mobile/src/components/Card/styles.ts
+++ b/mobile/src/components/Card/styles.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components/native';
+
+export const CardContainer = styled.View<{ ativo?: boolean }>`
+  background-color: #23242a;
+  border-radius: 16px;
+  padding: 18px;
+  margin-bottom: 18px;
+  position: relative;
+  opacity: ${({ ativo }) => (ativo ? 1 : 0.4)};
+`;


### PR DESCRIPTION
## Summary
- add generic `Card` component
- switch Home screen to use `Card` component
- remove obsolete `AlarmCard` styled component
- move Card styling to `Card/styles.ts`

## Testing
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6865e603df90832cabddfd2bbb016999